### PR TITLE
chore: upgrade aws-actions/configure-aws-credentials to use node16

### DIFF
--- a/.github/workflows/aws-ci-self-hosted-tests.yml
+++ b/.github/workflows/aws-ci-self-hosted-tests.yml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_CICD_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_CICD_SECRET_KEY }}

--- a/.github/workflows/aws-ci-synth.yml
+++ b/.github/workflows/aws-ci-synth.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup NodeJS
         uses: actions/setup-node@v3
         with:
@@ -41,7 +41,7 @@ jobs:
           registry-url: https://npm.pkg.github.com/
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_CICD_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_CICD_SECRET_KEY }}

--- a/.github/workflows/aws-ci-v2.yml
+++ b/.github/workflows/aws-ci-v2.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup NodeJS
         uses: actions/setup-node@v3
         with:
@@ -49,7 +49,7 @@ jobs:
           registry-url: https://npm.pkg.github.com/
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_CICD_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_CICD_SECRET_KEY }}

--- a/.github/workflows/aws-ci.yml
+++ b/.github/workflows/aws-ci.yml
@@ -35,7 +35,7 @@ jobs:
           registry-url: https://npm.pkg.github.com/
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
   
         # Add support for more platforms with QEMU (optional)
         # https://github.com/docker/setup-qemu-action
@@ -46,7 +46,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_CICD_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_CICD_SECRET_KEY }}


### PR DESCRIPTION
To fix these warnings

More info here:
- https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<img width="1204" alt="image" src="https://github.com/Bastion-Technologies/github_workflows/assets/45121661/a5e52dfb-9519-4970-9e76-184956523ce5">
