### PR TITLE
fix: disable enable-github-automerge-action

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -6,7 +6,14 @@ jobs:
   enable-auto-merge:
     runs-on: ubuntu-latest
     steps:
-    - uses: alexwilson/enable-github-automerge-action@main
-      with:
-        github-token: "${{ secrets.GITHUB_TOKEN }}"
-        merge-method: "SQUASH"
+      - run: echo "enable-auto-merge action has been temporarily disabled"
+      #   Disabled as deploys on main were not triggered (https://github.com/orgs/community/discussions/25702)
+      #   A workaround could be to use PATs but it's not ideal in terms of security
+      #   We could investigate
+      #   Also, alexwilson/enable-github-automerge-action@main can be replaced by gh pr merge --squash --auto
+      #
+      # - uses: alexwilson/enable-github-automerge-action@main
+      #   with:
+      #     github-token: "${{ secrets.GITHUB_TOKEN }}"
+      #     merge-method: "SQUASH"
+      #


### PR DESCRIPTION
<!-- PR Title should be: 
<type>(scope): <description>
with type: fix, feat, build, chore, ci, docs, style, refactor, perf, test
-->
# Description

Disabled as deploys on main were not triggered (https://github.com/orgs/community/discussions/25702)
A workaround could be to use PATs but it's not ideal in terms of security
We could investigate
Also, alexwilson/enable-github-automerge-action@main can be replaced by gh pr merge --squash --auto

Fixes # (notion ticket ID)

# Customer Facing
<!-- tick if your change is customer facing or leave it like that otherwise -->
-   [ ] Customer facing change

## Customer Facing Description
<!-- enter customer facing description if this change is customer facing -->

# How Has This Been Tested?
<!-- describe how the feature was testing -->
