### PR TITLE
fix: exclude node_modules from bundle upload

### DIFF
--- a/.github/workflows/build-upload-bundle.yml
+++ b/.github/workflows/build-upload-bundle.yml
@@ -106,7 +106,7 @@ jobs:
             - name: Upload
               run: |
                 echo $(pwd);
-                aws s3 cp ${{ inputs.bundle-path }} s3://bastion-bundles/${{ inputs.repo-name }}/${{ inputs.tag-version }} --recursive
+                aws s3 cp ${{ inputs.bundle-path }} s3://bastion-bundles/${{ inputs.repo-name }}/${{ inputs.tag-version }}  --exclude '*/node_modules/*' --recursive
             - name: Slack Notification
               if: "${{ failure() }}"
               uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
<!-- PR Title should be: 
<type>(scope): <description>
with type: fix, feat, build, chore, ci, docs, style, refactor, perf, test
-->
# Description
A week ago, I fixed an issue in `webapp-api-lambda` where a local dependency (specified with `file:`) was wrongly considered to have several versions, leading to a nested `node_modules` in a service folder, further leader to an issue when copying the cdk artifacts to s3 since the package was a relative symbolic link (which, once copied by cdk, pointed to nothing).
While `s3 cp` automatically skips the copy, the exit code of the command becomes `2`, leading to a workflow failure.

The fix was to regenerate the `package-lock.json` to let npm understand that there was a single version of the dependency used and only use the reference in the root `node_modules` without creating a nested one.

However, a couple days later, another pull request reintroduced the issue.
Since it doesn't seem possible to prevent this to happen again at any time (breaking the deploy flow), and since it seems we only need either zipped artifacts or containers, it seems to make sense to not copy `node_modules` to s3 since we don't actually need these for `cdk deploy`. **Please correct me if I'm wrong here**
This has the added benefit of increasing the workflow speed.

# Customer Facing
<!-- tick if your change is customer facing or leave it like that otherwise -->
-   [ ] Customer facing change

## Customer Facing Description
<!-- enter customer facing description if this change is customer facing -->

# How Has This Been Tested?
<!-- describe how the feature was testing -->
