### PR TITLE
fix: Add multi plateform build capabilities to build-upload-bundle workflow

### DIFF
--- a/.github/workflows/build-upload-bundle.yml
+++ b/.github/workflows/build-upload-bundle.yml
@@ -54,6 +54,10 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v3
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
             - name: Setup NodeJS
               uses: actions/setup-node@v3
               with:


### PR DESCRIPTION
<!-- PR Title should be: 
<type>(scope): <description>
with type: fix, feat, build, chore, ci, docs, style, refactor, perf, test
-->
# Description

Since we now have arm images, we need to add QEMU + BuildX to be able to successfully build these.
See this failed build for an example: https://github.com/Bastion-Technologies/webapp-api-lambda/actions/runs/6906263203/job/18790902023


# Customer Facing
<!-- tick if your change is customer facing or leave it like that otherwise -->
-   [ ] Customer facing change

## Customer Facing Description
<!-- enter customer facing description if this change is customer facing -->

# How Has This Been Tested?
<!-- describe how the feature was testing -->
