### PR TITLE
fix(build-upload-bundle): Add no-follow-symlinks to s3 cp

### DIFF
--- a/.github/workflows/build-upload-bundle.yml
+++ b/.github/workflows/build-upload-bundle.yml
@@ -110,7 +110,7 @@ jobs:
             - name: Upload
               run: |
                 echo $(pwd);
-                aws s3 cp ${{ inputs.bundle-path }} s3://bastion-bundles/${{ inputs.repo-name }}/${{ inputs.tag-version }}  --exclude '*/node_modules/*' --recursive
+                aws s3 cp ${{ inputs.bundle-path }} s3://bastion-bundles/${{ inputs.repo-name }}/${{ inputs.tag-version }}  --exclude '*/node_modules/*' --no-follow-symlinks --recursive
             - name: Slack Notification
               if: "${{ failure() }}"
               uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION


<!-- PR Title should be: 
<type>(scope): <description>
with type: fix, feat, build, chore, ci, docs, style, refactor, perf, test
-->
# Description
Following #16
It seems that, even with the `node_modules` folders excluded, s3 stills tries to follow symlinks inside these folders and fails, existing with a code 2 and failing the workflow. Since we're not supposed to have symlinks there, let's prevent s3 to follow any symlink.
# Customer Facing
<!-- tick if your change is customer facing or leave it like that otherwise -->
-   [ ] Customer facing change

## Customer Facing Description
<!-- enter customer facing description if this change is customer facing -->

# How Has This Been Tested?
<!-- describe how the feature was testing -->
