### PR TITLE
fix: Reinclude node_modules in build-upload-bundle s3 cp

### DIFF
--- a/.github/workflows/build-upload-bundle.yml
+++ b/.github/workflows/build-upload-bundle.yml
@@ -114,7 +114,7 @@ jobs:
             - name: Upload
               run: |
                 echo $(pwd);
-                aws s3 cp ${{ inputs.bundle-path }} s3://bastion-bundles/${{ inputs.repo-name }}/${{ inputs.tag-version }}  --exclude '*/node_modules/*' --no-follow-symlinks --recursive
+                aws s3 cp ${{ inputs.bundle-path }} s3://bastion-bundles/${{ inputs.repo-name }}/${{ inputs.tag-version }} --no-follow-symlinks --recursive
             - name: Slack Notification
               if: "${{ failure() }}"
               uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION


<!-- PR Title should be: 
<type>(scope): <description>
with type: fix, feat, build, chore, ci, docs, style, refactor, perf, test
-->
# Description

We excluded node_modules to solve an issue with a local reference as a symlink which made s3 cp exit with a non-zero exit code. However, we need to keep node_modules for some other stacks, notably `UserFriendlyNotificationsStack`.
Since the `--no-follow-symlinks` is enough to avoid an error in the original issue, let's reinclude node_modules.

# Customer Facing
<!-- tick if your change is customer facing or leave it like that otherwise -->
-   [ ] Customer facing change

## Customer Facing Description
<!-- enter customer facing description if this change is customer facing -->

# How Has This Been Tested?
<!-- describe how the feature was testing -->
