### PR TITLE
ci: Add api-upgrade Workflow

### DIFF
--- a/.github/workflows/api-upgrade.yml
+++ b/.github/workflows/api-upgrade.yml
@@ -1,0 +1,42 @@
+name: "API Upgrade"
+
+on:
+  workflow_call:
+    inputs:
+      api:
+        type: string
+        description: "API to upgrade"
+        required: false
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  main:
+    name: Upgrade
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      API: ${{ github.event.inputs.api || 'api' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Run upgrade
+        id: upgrade
+        run: |
+          SCRIPT=${{ github.event.inputs.api && format('upgrade-api:{0}', github.event.inputs.api) || 'upgrade-api' }}
+          VERSION=$(npm run $SCRIPT patch --silent)
+          echo "Upgraded ${{ github.event.inputs.api || 'api' }} to version $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "chore: Upgrade ${{ env.API }} to ${{ steps.upgrade.outputs.version }}"
+          title: "chore: Upgrade ${{ env.API }} to ${{ steps.upgrade.outputs.version }}"
+          body: |
+            Upgrade ${{ env.API }} to ${{ steps.upgrade.outputs.version }}
+          branch: "upgrade-${{env.API}}-${{ steps.upgrade.outputs.version }}"
+          base: "main"


### PR DESCRIPTION
<!-- PR Title should be: 
<type>(scope): <description>
with type: fix, feat, build, chore, ci, docs, style, refactor, perf, test
-->
# Description

This worklow is meant to be used in other repos with a schedule trigger.

It will automatically upgrade the provided api (using `npm run upgrade-api:<api>`) or the default one if none is passed (using `npm run upgrade-api`) with a patch version.
It will then open a new PR containing the upgrade.

Note that it may be interesting to prefix the PR name with something distinctive so we can merge it automatically with Nautilus.

# Customer Facing
<!-- tick if your change is customer facing or leave it like that otherwise -->
-   [ ] Customer facing change

## Customer Facing Description
<!-- enter customer facing description if this change is customer facing -->

# How Has This Been Tested?
<!-- describe how the feature was testing -->
