### PR TITLE
chore(npm-package-release): Remove tag-bundle-to-s3 call

### DIFF
--- a/.github/workflows/npm-package-release.yml
+++ b/.github/workflows/npm-package-release.yml
@@ -46,8 +46,6 @@ jobs:
     needs: should-publish
     if: needs.should-publish.outputs.isdiff == 'yes'
     runs-on: ubuntu-latest
-    permissions:
-      actions: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -77,16 +75,3 @@ jobs:
               ref: 'refs/tags/${{ inputs.library-name }}-${{ steps.package-version.outputs.current-version}}',
               sha: context.sha
             })
-
-      - name: Call tag-bundle-to-s3
-        uses: actions/github-script@v5
-        with:
-            script: |
-                const tagName = "${{ inputs.library-name }}-${{ steps.package-version.outputs.current-version}}"
-
-                github.rest.actions.createWorkflowDispatch({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    workflow_id: 'tag-bundle-to-s3.yml',
-                    ref: tagName
-                })


### PR DESCRIPTION

<!-- PR Title should be: 
<type>(scope): <description>
with type: fix, feat, build, chore, ci, docs, style, refactor, perf, test
-->
# Description

We want to do that in another reusable workflow since not all repos using npm-package-release will bundle / upload to s3 (a good example is bastion libs).
This will also unblock the api release jobs as some repos currently have a permission mismatch.


# Customer Facing
<!-- tick if your change is customer facing or leave it like that otherwise -->
-   [ ] Customer facing change

## Customer Facing Description
<!-- enter customer facing description if this change is customer facing -->

# How Has This Been Tested?
<!-- describe how the feature was testing -->
