### PR TITLE
feat: Add update-bt-dependencies workflow

### DIFF
--- a/.github/workflows/update-bt-dependencies.yml
+++ b/.github/workflows/update-bt-dependencies.yml
@@ -1,0 +1,55 @@
+name: Update BT Dependencies
+
+on:
+  workflow_call:
+    secrets:
+      NAUTILUS_SHARED_SECRET:
+        required: true
+
+jobs:
+  update-bt-dependencies:
+    name: Update BT Dependencies
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' && contains(github.ref_name, 'bastion-technologies') }}
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Comment PR
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.inputs.prNumber }}
+          body: |
+            :robot: Bastion API upgrade detected, automatically updating BT Dependencies :robot:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Update BT Dependencies
+        run: |
+          npm run nautilus
+      - name: Create new branch
+        run: |
+          git config --global user.name "${GITHUB_ACTOR}"
+          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+      
+          git switch -c ${{ github.ref_name }}-bt-dependencies
+          git commit -am "chore: update BT dependencies"
+          git push --set-upstream origin ${{ github.ref_name }}-bt-dependencies --force
+
+  pr:
+    needs: update-bt-dependencies
+    name: Create Pull Request
+    uses: Bastion-Technologies/github_workflows/.github/workflows/nautilus-pr.yml@main
+    with:
+      repo: ${{ github.repository }}
+      branch: ${{ github.ref_name }}-bt-dependencies
+      base: ${{ github.ref_name }}
+      title: "chore: update BT dependencies for #${{ github.event.inputs.prNumber }}"
+      body: |
+        :robot: Bastion API upgrade detected, automatically updating BT Dependencies :robot:
+    secrets:
+      NAUTILUS_SHARED_SECRET: ${{ secrets.NAUTILUS_SHARED_SECRET }}


### PR DESCRIPTION
This will allow us to automatically create a new branch / PR to update the bt_dependencies file when dependabot automatically upgrades a Bastion API.

<!-- PR Title should be: 
<type>(scope): <description>
with type: fix, feat, build, chore, ci, docs, style, refactor, perf, test
-->
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (notion ticket ID)

# Customer Facing
<!-- tick if your change is customer facing or leave it like that otherwise -->
-   [ ] Customer facing change

## Customer Facing Description
<!-- enter customer facing description if this change is customer facing -->

# How Has This Been Tested?
<!-- describe how the feature was testing -->
