### PR TITLE
feat(package-version-changed): Add API breaking changes check

### DIFF
--- a/.github/workflows/package-version-changed.yml
+++ b/.github/workflows/package-version-changed.yml
@@ -76,3 +76,45 @@ jobs:
               repo: context.repo.repo,
               body: "✅ You are updating library ${{ inputs.library-name }} to version ${{ env.CURRENT }}."
             })
+
+  check-api-breaking-changes:
+    needs: check-if-changed
+    if: needs.check-if-changed.outputs.isdiff == 'yes'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Retrieve API definition file
+        run: |
+          mkdir -p ./.tmp
+
+          API_FILE_PATH=$(find . -name ${{ inputs.library-name }}.yaml)
+
+          git show origin/main:$API_FILE_PATH > ./.tmp/${{ inputs.library-name }}-base.yaml
+          cp -p $API_FILE_PATH ./.tmp/${{ inputs.library-name }}-revision.yaml
+      - name: Check API breaking changes
+        id: oasdiff
+        run: |
+          docker run --rm -v ./.tmp:/apis -t tufin/oasdiff breaking /apis/${{ inputs.library-name }}-base.yaml /apis/${{ inputs.library-name }}-revision.yaml --format text --color never --fail-on WARN >> report && exitCode=$? || exitCode=$?
+
+          echo "HEADER=$(cat report | head -n 1)" >> "$GITHUB_OUTPUT"
+          echo "REPORT<<EOF" >> "$GITHUB_OUTPUT"
+          cat report | tail -n+2 | head -n-2 >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          exit $exitCode
+      - name: Post oasdiff report
+        if: ${{ always() }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: oasdiff
+          message: |
+            <!-- bot:oasdiff -->
+            # BREAKING CHANGES
+            ## ${{ steps.oasdiff.outputs.HEADER }}
+            ```
+            ${{ steps.oasdiff.outputs.REPORT }}
+            ```
+
+            Please fix the breaking changes before merging this PR or reach a GitHub admin to approve the breaking changes.


### PR DESCRIPTION
<!-- PR Title should be: 
<type>(scope): <description>
with type: fix, feat, build, chore, ci, docs, style, refactor, perf, test
-->
# Description

This new job will run the [oasdiff](https://github.com/Tufin/oasdiff) tool to detect breaking changes if the API has changed.
This is motivated by the fact that we want to avoid breaking changes for our consumers.

### Technical considerations
- We use the docker image directly instead of the Github Action wrapper to have a better control over the output, since the wrapper (unfortunately) omits the breaking changes details. This does not change the average running time of the action (~30s).
- This tool was chosen over others (such as [OpenAPITools'](https://github.com/OpenAPITools/openapi-diff) or [Atlassian's](https://bitbucket.org/atlassian/openapi-diff/src/master/)) because it's more flexible and maintained.
 
# Customer Facing
<!-- tick if your change is customer facing or leave it like that otherwise -->
-   [ ] Customer facing change

## Customer Facing Description
<!-- enter customer facing description if this change is customer facing -->

# How Has This Been Tested?
<!-- describe how the feature was testing -->
