### PR TITLE
chore(package-version-changed): Filter response-property-enum-value-added warning from breaking changes check

### DIFF
--- a/.github/workflows/package-version-changed.yml
+++ b/.github/workflows/package-version-changed.yml
@@ -82,7 +82,7 @@ jobs:
     if: needs.check-if-changed.outputs.isdiff == 'yes'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -97,11 +97,21 @@ jobs:
       - name: Check API breaking changes
         id: oasdiff
         run: |
-          docker run --rm -v ./.tmp:/apis -t tufin/oasdiff breaking /apis/${{ inputs.library-name }}-base.yaml /apis/${{ inputs.library-name }}-revision.yaml --format text --color never --fail-on WARN >> report && exitCode=$? || exitCode=$?
+          docker run --rm -v ./.tmp:/apis -t tufin/oasdiff breaking /apis/${{ inputs.library-name }}-base.yaml /apis/${{ inputs.library-name }}-revision.yaml --format json --fail-on WARN > report && exitCode=$? || exitCode=$?
 
-          echo "HEADER=$(cat report | head -n 1)" >> "$GITHUB_OUTPUT"
+          # Removes the response-property-enum-value-added warning
+          REPORT_FILTERED=$(cat report  | jq '[.[] | select ( .id != "response-property-enum-value-added" )]')
+
+          # Format and extract counts
+          REPORT_TEXT=$(echo "$REPORT_FILTERED" | jq -r '.[] | if .level == 2 then "warning" else "error" end + "\t[\(.id)] at \(.source)\n\tin API \(.operation) \(.path)\n\t\t\(.text)\n"')
+          WARNING_COUNT=$(echo "$REPORT_TEXT" | grep -c "^warning")
+          ERROR_COUNT=$(echo "$REPORT_TEXT" | grep -c "^error")
+          TOTAL_COUNT=$((WARNING_COUNT + ERROR_COUNT))
+          HEADER="$TOTAL_COUNT breaking change(s): $ERROR_COUNT error(s), $WARNING_COUNT warning(s)"
+
+          echo "HEADER=$HEADER" >> "$GITHUB_OUTPUT"
           echo "REPORT<<EOF" >> "$GITHUB_OUTPUT"
-          cat report | tail -n+2 | head -n-2 >> "$GITHUB_OUTPUT"
+          echo "$REPORT_TEXT" | head -n-1 >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
 
           exit $exitCode


### PR DESCRIPTION
<!-- PR Title should be: 
<type>(scope): <description>
with type: fix, feat, build, chore, ci, docs, style, refactor, perf, test
-->
# Description
We don't want to block pull requests if we add values to enums but oasdiff consider this as a warning and fails.
Considering that:
- We want to keep the warning level for other checks
- The [recommended and working solution](https://github.com/Tufin/oasdiff/blob/main/BREAKING-CHANGES.md#breaking-changes-to-enum-values) is to use `x-extensible-enum` instead but AJV doesn't recognize it
- oasdiff does not provide an easy way to filter specific checks

We have to do the filtering ourselves.
This code does the following:
- Outputs the report as JSON instead of text for easier manipulation
- Filters out the response-property-enum-value-added warnings
- Counts the remaining errors and warnings to reproduce the text header outputed by oasdiff text
- Formats the JSON the same way than oasdiff text

# Customer Facing
<!-- tick if your change is customer facing or leave it like that otherwise -->
-   [ ] Customer facing change

## Customer Facing Description
<!-- enter customer facing description if this change is customer facing -->

# How Has This Been Tested?
<!-- describe how the feature was testing -->
