### PR TITLE
fix(api-upgrade): Use hardcoded nautilus user instead of GITHUB_ACTOR

### DIFF
--- a/.github/workflows/api-upgrade.yml
+++ b/.github/workflows/api-upgrade.yml
@@ -71,8 +71,8 @@ jobs:
           UPGRADE_BRANCH=upgrade-${{env.API}}-$VERSION
           echo "Upgraded ${{ env.API }} to version $VERSION"
           
-          git config --global user.name "${GITHUB_ACTOR}"
-          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config --global user.name "nautilus-bot-1"
+          git config --global user.email "nautilus-bot-1@users.noreply.github.com"
 
           git switch -c "$UPGRADE_BRANCH"
           git commit -am "chore: Upgrade ${{ env.API }} to $VERSION"


### PR DESCRIPTION
GITHUB_ACTOR is supposed to be set to the user who triggered the workflow. Is the case of a scheduled workflow, it seems to be set to the user who created it.
However, it wasn't set in a couple of repos (probably those where I never committed) so it will be safer if we use a hardcoded user instead.

<!-- PR Title should be: 
<type>(scope): <description>
with type: fix, feat, build, chore, ci, docs, style, refactor, perf, test
-->
# Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (notion ticket ID)

# Customer Facing
<!-- tick if your change is customer facing or leave it like that otherwise -->
-   [ ] Customer facing change

## Customer Facing Description
<!-- enter customer facing description if this change is customer facing -->

# How Has This Been Tested?
<!-- describe how the feature was testing -->
