### PR TITLE
chore(aws-ci-synth): Run synth job only if CDK changed

### DIFF
--- a/.github/workflows/aws-ci-synth.yml
+++ b/.github/workflows/aws-ci-synth.yml
@@ -154,12 +154,27 @@ jobs:
           npm test -- ${{ matrix.workspace }} --passWithNoTests;
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"
+
+  has-cdk-changed:
+    name: Has CDK changed
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check if CDK changed
+        run: |
+          git diff --name-only origin/main HEAD | grep -q 'cdk/.*\.ts$' && hasChanged=true || hasChanged=false
+          echo "Has CDK Changed: $hasChanged"
+          echo "CDK_CHANGED=$hasChanged" >> "$GITHUB_OUTPUT"
   synth-check:
     name: CDK Synth
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: ${{ github.actor != 'dependabot[bot]' }}
-    needs: [build]
+    if: ${{ github.actor != 'dependabot[bot]' }} && needs.has-cdk-changed.outputs.CDK_CHANGED == 'true'
+    needs: [build, has-cdk-changed]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
<!-- PR Title should be: 
<type>(scope): <description>
with type: fix, feat, build, chore, ci, docs, style, refactor, perf, test
-->
# Description

Introduce a new job checking if any `.ts` file changed under the `cdk/` folder, allowing to run the `synth` job only if the previous check returns true

# Customer Facing
<!-- tick if your change is customer facing or leave it like that otherwise -->
-   [ ] Customer facing change

## Customer Facing Description
<!-- enter customer facing description if this change is customer facing -->

# How Has This Been Tested?
<!-- describe how the feature was testing -->
