### PR TITLE
fix(aws-ci-synth): include workspace root on compile and lint steps

### DIFF
--- a/.github/workflows/aws-ci-synth.yml
+++ b/.github/workflows/aws-ci-synth.yml
@@ -92,7 +92,7 @@ jobs:
           path: "**/node_modules/**"
       - name: Typescript checking
         run: |
-          npm run compile --workspaces --if-present;
+          npm run compile --workspaces --if-present --include-workspace-root;
   linter-check:
     name: Linter checking
 
@@ -111,7 +111,7 @@ jobs:
           path: "**/node_modules/**"
       - name: Linter checking
         run: |
-          npm run lint --workspaces --if-present;
+          npm run lint --workspaces --if-present --include-workspace-root;
   list-workspaces:
     name: List workspaces
     runs-on: ubuntu-latest

--- a/.github/workflows/nautilus-merge.yml
+++ b/.github/workflows/nautilus-merge.yml
@@ -20,7 +20,7 @@ on:
         required: true
 
 jobs:
-  create-pull-request:
+  merge-pull-request:
     runs-on: ubuntu-latest
     steps:
       - name: Query Nautilus to merge a PR


### PR DESCRIPTION
<!-- PR Title should be: 
<type>(scope): <description>
with type: fix, feat, build, chore, ci, docs, style, refactor, perf, test
-->
# Description

The original commands were ignoring the root package.json when running the `compile` and `lint` scripts.
Most of the repos only have the `lint` script in the root file so it means the step wasn't properly working for these.

Also fixing nautilus-merge job name.


# Customer Facing
<!-- tick if your change is customer facing or leave it like that otherwise -->
-   [ ] Customer facing change

## Customer Facing Description
<!-- enter customer facing description if this change is customer facing -->

# How Has This Been Tested?
<!-- describe how the feature was testing -->
