### PR TITLE
Revert "ci(lint-pr): Add ADR check"

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -54,7 +54,3 @@ jobs:
         with:   
           header: pr-title-lint-error
           delete: true
-
-  check-adr:
-    name: Check ADR
-    uses: Bastion-Technologies/github_workflows/.github/workflows/check-adr.yml@main


### PR DESCRIPTION
Reverts Bastion-Technologies/github_workflows#90

Missing permission in calling workflows (`content:read`)
It's blocking the PRs
I'll need to update every repos again :(