### PR TITLE
chore: Ignore existing PR

### DIFF
--- a/.github/workflows/lokalise-pull.yml
+++ b/.github/workflows/lokalise-pull.yml
@@ -19,6 +19,9 @@ jobs:
   pull:
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.commit.outputs.has_changes }}
+      branch_name: ${{ steps.commit.outputs.branch_name }}
     steps:
       - uses: actions/checkout@v3
       - name: Lokalise CLI
@@ -31,6 +34,7 @@ jobs:
         run: |
              ./bin/lokalise2 --token ${{ env.VAR_LOKALISE_API_TOKEN }} --project-id ${{ env.VAR_LOKALISE_PROJECT_ID }} file download --json-unescaped-slashes --format json --original-filenames=true --directory-prefix=/
       - name: Commit
+        id: commit
         env: 
           GH_TOKEN: ${{ github.token }}
           VAR_BRANCH_NAME: 'lokalise/translation-udpate'
@@ -47,17 +51,22 @@ jobs:
             else
                 git commit -m 'chore: Lokalise translations update'
                 git push origin ${{ env.VAR_BRANCH_NAME }} --force
-                # Creates the PR. This is the same as:
-                #     gh pr view ${{ env.VAR_BRANCH_NAME }} && gh pr reopen ${{ env.VAR_BRANCH_NAME }} || gh pr create --fill -B main -H ${{ env.VAR_BRANCH_NAME }} --title 'chore: Lokalise translations' --body 'Automatically created by Github action'
-                curl --location 'https://dev.bastion.tech/api/nautilus/pr' \
-                  --header 'Content-Type: application/json' \
-                  --header 'x-shared-secret: ${{ secrets.NAUTILUS_SHARED_SECRET }}' \
-                  --fail-with-body \
-                  --data '{
-                      "repo": "${{ github.repository }}",
-                      "base": "main",
-                      "head": "${{ env.VAR_BRANCH_NAME }}",
-                      "title": "chore: Lokalise translations",
-                      "body": "Automatically created by Github action"
-                  }'
+
+                echo "has_changes=true" >> "$GITHUB_OUTPUT"
+                echo "branch_name=${{ env.VAR_BRANCH_NAME }}" >> "$GITHUB_OUTPUT"
             fi
+
+  pr:
+    name: Create Pull Request
+    needs: pull
+    if: ${{ needs.pull.outputs.has_changes == 'true' }}
+    uses: Bastion-Technologies/github_workflows/.github/workflows/nautilus-pr.yml@main
+    with:
+      repo: ${{ github.repository }}
+      base: main
+      branch: ${{ needs.pull.outputs.branch_name }}
+      title: "chore: Lokalise translations"
+      body: "Automatically created by Github action"
+      ignoreExistingPR: true
+    secrets:
+      NAUTILUS_SHARED_SECRET: ${{ secrets.NAUTILUS_SHARED_SECRET }}

--- a/.github/workflows/nautilus-pr.yml
+++ b/.github/workflows/nautilus-pr.yml
@@ -20,6 +20,10 @@ on:
         required: true
         type: string
         default: ${{ github.repository }}
+      ignoreExistingPR:
+        required: false
+        type: boolean
+        default: false
     secrets:
       NAUTILUS_SHARED_SECRET:
         required: true
@@ -39,6 +43,7 @@ jobs:
                       "base": "${{ inputs.base }}",
                       "head": "${{ inputs.branch }}",
                       "title": "${{ inputs.title }}",
-                      "body": "${{ inputs.body }}"
+                      "body": "${{ inputs.body }}",
+                      "ignoreExistingPR": ${{ inputs.ignoreExistingPR }}
                   }'
       


### PR DESCRIPTION
<!-- PR Title should be: 
<type>(scope): <description>
with type: fix, feat, build, chore, ci, docs, style, refactor, perf, test
-->
# Description

- Add `ignoreExistingPR` option to nautilus-pr workflow
- Use nautilus-pr workflow in localise-pull workflow

# Customer Facing
<!-- tick if your change is customer facing or leave it like that otherwise -->
-   [ ] Customer facing change

## Customer Facing Description
<!-- enter customer facing description if this change is customer facing -->

# How Has This Been Tested?
<!-- describe how the feature was testing -->

# Checks
<!-- If your PR is a fix or a small improvement, it usually doesn't need an ADR.
     However for a feature or a big improvement, you should document why we do it
     for traceability.
-->
- [x] This PR doesn´t need an ADR