### PR TITLE
fix(aws-ci-synth): Ignore NX unknown local cache

### DIFF
--- a/.github/workflows/aws-ci-synth.yml
+++ b/.github/workflows/aws-ci-synth.yml
@@ -190,7 +190,7 @@ jobs:
           IS_PROJECT_AFFECTED=$(npx nx show projects --affected --with-target test | grep -q $PROJECT && echo "true" || echo "false")
           if [ $IS_PROJECT_AFFECTED == "true" ]
             then
-                npx nx test $PROJECT --passWithNoTests;
+            NX_REJECT_UNKNOWN_LOCAL_CACHE=0 npx nx test $PROJECT --passWithNoTests;
             else
                echo "Project not affected, skipping tests";
           fi


### PR DESCRIPTION


<!-- PR Title should be: 
<type>(scope): <description>
with type: fix, feat, build, chore, ci, docs, style, refactor, perf, test
-->
# Description
This happens because the cache was generated on another runner and NX doesn't remote trust cache artifacts by defaut to avoid cache poisoning.

See https://nx.dev/troubleshooting/unknown-local-cache

# Customer Facing
<!-- tick if your change is customer facing or leave it like that otherwise -->
-   [ ] Customer facing change

## Customer Facing Description
<!-- enter customer facing description if this change is customer facing -->

# How Has This Been Tested?
<!-- describe how the feature was testing -->

# Checks
<!-- If your PR is a fix or a small improvement, it usually doesn't need an ADR.
     However for a feature or a big improvement, you should document why we do it
     for traceability.
-->
- [x] This PR doesn´t need an ADR