### PR TITLE
fix: force esbuild@^0.23.0 when installed globally

### DIFF
--- a/.github/workflows/aws-ci-self-hosted-tests.yml
+++ b/.github/workflows/aws-ci-self-hosted-tests.yml
@@ -46,7 +46,7 @@ jobs:
           role-session-name: GitActionDeploymentSession
 
       - name: Prerequisite Installation
-        run: npm install -g aws-cdk esbuild
+        run: npm install -g aws-cdk esbuild@^0.23.0
 
       - name: install dependencies
         run: |

--- a/.github/workflows/aws-ci-synth.yml
+++ b/.github/workflows/aws-ci-synth.yml
@@ -192,7 +192,7 @@ jobs:
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"
       - uses: nrwl/nx-set-shas@v3
-        if: ${{ needs.check-if-nx-workspace.outputs.isNxWorkspace == 'true' }} 
+        if: ${{ needs.check-if-nx-workspace.outputs.isNxWorkspace == 'true' }}
       - name: Run unit tests (NX)
         if: ${{ needs.check-if-nx-workspace.outputs.isNxWorkspace == 'true' }}
         run: |
@@ -256,7 +256,7 @@ jobs:
           role-session-name: GitActionDeploymentSession
 
       - name: Prerequisite Installation
-        run: npm install -g aws-cdk esbuild
+        run: npm install -g aws-cdk esbuild@^0.23.0
       - name: Check cdk synth
         run: |
           cd cdk;

--- a/.github/workflows/aws-ci-v2.yml
+++ b/.github/workflows/aws-ci-v2.yml
@@ -67,7 +67,7 @@ jobs:
           role-session-name: GitActionDeploymentSession
 
       - name: Prerequisite Installation
-        run: npm install -g aws-cdk esbuild
+        run: npm install -g aws-cdk esbuild@^0.23.0
 
       - name: install dependencies
         run: |

--- a/.github/workflows/build-upload-bundle.yml
+++ b/.github/workflows/build-upload-bundle.yml
@@ -3,7 +3,7 @@ name: Build and upload bundles
 on:
     workflow_call:
         inputs:
-            bundle-path: 
+            bundle-path:
                 required: true
                 type: string
             repo-name:
@@ -35,7 +35,7 @@ on:
                 required: true
             SLACK_WEBHOOK_PROD:
                 required: true
-  
+
 
 jobs:
     deploy:
@@ -70,7 +70,7 @@ jobs:
                   cache-dependency-path: "**/package-lock.json"
                   registry-url: https://npm.pkg.github.com/
             - name: Prerequisite Installation
-              run: npm install -g aws-cdk esbuild
+              run: npm install -g aws-cdk esbuild@^0.23.0
 
             - name: install dependencies
               run: |


### PR DESCRIPTION
# Description

Update esbuild version (force `^0.23.0`) (used internally by aws-cdk-lib when building lambda).

Fixes # (notion ticket ID)

# Customer Facing
<!-- tick if your change is customer facing or leave it like that otherwise -->
-   [ ] Customer facing change

## Customer Facing Description
<!-- enter customer facing description if this change is customer facing -->

# How Has This Been Tested?
<!-- describe how the feature was testing -->

# Checks
<!-- If your PR is a fix or a small improvement, it usually doesn't need an ADR.
     However for a feature or a big improvement, you should document why we do it
     for traceability.
-->
- [x] This PR doesn´t need an ADR